### PR TITLE
Link to block

### DIFF
--- a/lib/roles_on_routes/action_view_extensions/tags_with_roles.rb
+++ b/lib/roles_on_routes/action_view_extensions/tags_with_roles.rb
@@ -6,8 +6,17 @@ require 'action_controller'
 module RolesOnRoutes
   module ActionViewExtensions
     module TagsWithRoles
-      def link_to_with_roles(link_text, poly_array, options={})
-        link_to link_text, poly_array, options.merge({ RolesOnRoutes::TAG_ROLES_ATTRIBUTE => roles_from_polymorphic_array(poly_array).join(' ') })
+      def link_to_with_roles(*args, &block)
+        if block_given?
+          html_options_index = 1
+          options = args.first
+        else
+          html_options_index = 2
+          options = args.second
+        end
+        html_options = args[html_options_index] ||= {}
+        html_options.merge!({ RolesOnRoutes::TAG_ROLES_ATTRIBUTE => roles_from_options(options).join(' ') })
+        link_to *args, &block
       end
 
       def content_tag_with_roles(tag_type, roleset, options={}, &block)
@@ -23,8 +32,8 @@ module RolesOnRoutes
 
     private
 
-      def roles_from_polymorphic_array(array)
-        RolesOnRoutes::Base.roles_for(url_for(array))
+      def roles_from_options(options)
+        RolesOnRoutes::Base.roles_for(url_for(options))
       end
     end
   end

--- a/roles_on_routes.gemspec
+++ b/roles_on_routes.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Define your authorization roles on the routes they apply to'
   s.description = %q{ }
 
-  s.add_dependency 'actionpack', '>= 3.0'
+  s.add_dependency 'actionpack', '~> 3.0'
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_development_dependency 'rspec', '~> 2.6.0'
 

--- a/spec/action_view_extensions/tags_with_routes_spec.rb
+++ b/spec/action_view_extensions/tags_with_routes_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'roles_on_routes/action_view_extensions/tags_with_roles'
 require 'ostruct'
 

--- a/spec/action_view_extensions/tags_with_routes_spec.rb
+++ b/spec/action_view_extensions/tags_with_routes_spec.rb
@@ -1,6 +1,8 @@
 require 'roles_on_routes/action_view_extensions/tags_with_roles'
 require 'ostruct'
 
+include ActionView::Helpers::TagHelper
+
 class AnimalsController
 end
 
@@ -26,6 +28,7 @@ describe 'ActionDispatch::Routing::Routeset#roles_for' do
     let(:routeset) { ActionDispatch::Routing::RouteSet.new }
     let(:link_text)   { 'Link Text' }
     let(:action_view) { ActionView::Base.new }
+    let(:block)       { nil }
 
     before do
       routeset.draw do
@@ -50,6 +53,13 @@ describe 'ActionDispatch::Routing::Routeset#roles_for' do
       let (:polymorphic_array) { [Animal.new] }
       it { should include('<a href="/animals/1"') }
       it { should include("#{RolesOnRoutes::TAG_ROLES_ATTRIBUTE}=\"staff not_staff\"") }
+    end
+
+    context 'taking a block' do
+      let (:polymorphic_array) { [Animal.new] }
+      let (:block) { Proc.new { content_tag(:span, 'Special Animal') } }
+      subject { action_view.link_to_with_roles(polymorphic_array, {}, &block) }
+      it { should include('<span>') }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'roles_on_routes'
+require 'roles_on_routes/version'
+require 'rspec'
+
+RSpec.configure do |config|
+  # Use color in STDOUT
+  config.color_enabled = true
+
+  # Use color not only in STDOUT but also in pagers and files
+  config.tty = true
+
+  # Use the specified formatter
+  config.formatter = :documentation # :progress, :html, :textmate
+end


### PR DESCRIPTION
This commit adds the capability for `link_to` to take a block, just like the Rails `link_to` helper.

It also adds a constraint for the version of `actionpack`, as well as a `spec_helper` file that adds colored output.
