### PR TITLE
Refactor base_spec to read clearly, add documentation

### DIFF
--- a/spec/roles_on_routes/base_spec.rb
+++ b/spec/roles_on_routes/base_spec.rb
@@ -1,4 +1,4 @@
-require 'roles_on_routes/base'
+require 'roles_on_routes'
 require 'ostruct'
 require 'debugger'
 
@@ -10,81 +10,98 @@ class CatsController
 end
 
 describe RolesOnRoutes::Base do
-  describe '#roles_for' do
-    let(:routeset)    { ActionDispatch::Routing::RouteSet.new }
-    let(:link_text)   { 'Link Text' }
-    let(:action_view) { ActionView::Base.new }
-    let(:path)        { '/animals' }
-    let(:action)      { 'GET' }
-    let(:roleset)     { [:staff] }
+  let(:routeset)    { ActionDispatch::Routing::RouteSet.new }
 
-    before do
-      r = roleset # Scoping problem when defining routes if only set in lets
+  before do
+    r = roleset # Scoping problem when defining routes if only set in lets
 
-      RolesOnRoutes::Configuration.define_roles do
-        add :not_staff, [:not_staff]
-        add :admin,     [:admin]
-        add :penguins,  [:penguin_handler, :penguin_trainer]
-        add :staff_block do
-          [:staff]
-        end
+    RolesOnRoutes::Configuration.define_roles do
+      add :not_staff, [:not_staff]
+      add :admin,     [:admin]
+      add :penguins,  [:penguin_handler, :penguin_trainer]
+      add :staff_block do
+        [:staff]
       end
+    end
 
-      routeset.draw do
-        scope roles: :staff_block do
-          resources :animals, action_roles: { not_staff: :show } do
-            resources :cats
-            resources :rats, action_roles: { admin: [:index] }
-            member do
-              get :penguin, roles: :penguins
-            end
+    routeset.draw do
+      scope roles: :staff_block do
+        resources :animals, action_roles: { not_staff: :show } do
+          resources :cats
+          resources :rats, action_roles: { admin: [:index] }
+          member do
+            get :penguin, roles: :penguins
           end
         end
       end
-      RolesOnRoutes::Configuration.routeset_containing_roles = routeset
     end
+    RolesOnRoutes::Configuration.routeset_containing_roles = routeset
+  end
+
+
+  describe '#roles_for' do
 
     subject { RolesOnRoutes::Base.roles_for(path, action) }
 
-    context 'bad path' do
-      let (:path) { '/donkey' }
-      it { expect{ subject }.to raise_error }
-    end
+    let(:path)    { '/animals' }
+    let(:action)  { 'GET' }
+    let(:roleset) { [:staff] }
 
-    context 'animals controller' do
-      context 'cats index' do
-        let (:path) { '/animals/1/cats' }
-        it { should == [:staff] }
-      end
-
-      context 'cats show' do
-        let (:path) { '/animals/1/cats/2' }
-        it { should == [:staff] }
-      end
-
-      context 'rats index' do
-        let (:path) { '/animals/1/rats' }
-        it { should == [:admin] }
-      end
-
-      context 'rats show' do
-        let (:path) { '/animals/1/rats/2' }
-        it { should == [:staff] }
-      end
-
-      context 'penguin get' do
-        let (:path) { '/animals/1/penguin' }
-        it { should == [:penguin_handler, :penguin_trainer] }
-      end
-
-      context 'animals index' do
+    context 'non-nested route' do
+      context 'with base role definition' do
         let (:path) { '/animals' }
         it { should == [:staff] }
       end
 
-      context 'animals show' do
+      context 'with action role override' do
         let (:path) { '/animals/1' }
         it { should == [:not_staff] }
+      end
+    end
+
+    context 'nested route' do
+      let (:path) { '/animals/1/cats' }
+      context 'with no role definition' do
+        it 'inherits parent roles' do
+          subject.should == [:staff]
+        end
+      end
+
+      context 'with parent action role' do
+        let (:path) { '/animals/1/cats/1' }
+        it 'does not inherit action_roles' do
+          subject.should == [:staff]
+        end
+      end
+
+      context 'with action role' do
+        let (:path) { '/animals/1/rats' }
+        it 'overrides role' do
+          subject.should == [:admin]
+        end
+      end
+
+      context 'without action role' do
+        let (:path) { '/animals/1/rats/2' }
+        it 'does not override' do
+          subject.should == [:staff]
+        end
+      end
+
+      context 'member routing' do
+        context 'defines non-RESTful roles without action_roles hash' do
+          let (:path) { '/animals/1/penguin' }
+          it 'overrides role' do
+            subject.should == [:penguin_handler, :penguin_trainer]
+          end
+        end
+      end
+    end
+
+    context 'bad path' do
+      let (:path) { '/donkey' }
+      it 'raises an exception' do
+        expect{ subject }.to raise_error(ActionController::RoutingError)
       end
     end
   end


### PR DESCRIPTION
This commit refactors the `base_spec` file to read more clearly and to tell a clearer story of what `roles_on_routes` is doing.

by Steve & Nick
