### PR TITLE
Guarantee access is denied if not authorized

### DIFF
--- a/lib/roles_on_routes/roles_on_routes_controller.rb
+++ b/lib/roles_on_routes/roles_on_routes_controller.rb
@@ -15,6 +15,9 @@ module RolesOnRoutes
     def authorize_from_role_intersection
       return true if ::RolesOnRoutes::Base.authorizes?(request, current_user_roles)
       role_authorization_failure_response
+      # Guarantee access is denied if not authorized, in case
+      # role_authorization_failure_response fails to render or redirect.
+      render nothing: true, status: :unauthorized unless performed?
     end
 
     def current_user_roles
@@ -22,8 +25,6 @@ module RolesOnRoutes
       super
     end
 
-    # If you override this, make sure it calls redirect_to or render in order
-    # to protect against unauthorized access and CSRF.
     def role_authorization_failure_response
       render nothing: true, status: :unauthorized
     end


### PR DESCRIPTION
Note on how this impacts the gc (guiding cancer) app:

Something in RestDefaultsController causes a redirect to the login page
even if the definition of role_authorization_failure_response in
AuthorizesWithRoles does not render or redirect.

But if you include AuthorizesWithRoles in a controller, you don't include
RestDefaultsController, and role_authorization_failure_response does not
render or redirect, then the filter chain will not be halted and the
request will be served as if the user is authorized. That's one case that
makes this commit worth doing.